### PR TITLE
Improve wave generator randomness

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,24 @@
-fart machine
+# Fart Machine
+
+This repository contains a simple example of generating a sawtooth wave in Python.
+
+The `saw_wave.py` script plays a low-pitched sawtooth wave using `numpy` and `sounddevice`.
+Each run picks a new random frequency between 30 Hz and 45 Hz. Durations
+are clamped to the range 0.1–3 seconds.
+
+## Requirements
+
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run the script to play a randomly pitched sawtooth wave. The default duration is
+2&nbsp;seconds (values outside 0.1–3&nbsp;seconds are clamped):
+
+```bash
+python saw_wave.py
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+numpy
+sounddevice

--- a/saw_wave.py
+++ b/saw_wave.py
@@ -1,0 +1,49 @@
+import numpy as np
+import sounddevice as sd
+import random
+
+
+def saw_wave(freq, time_array):
+    """Generate a sawtooth wave.
+
+    Parameters
+    ----------
+    freq : float
+        Frequency of the wave in Hz.
+    time_array : numpy.ndarray
+        Array of time values.
+
+    Returns
+    -------
+    numpy.ndarray
+        The sawtooth waveform sampled at the times provided.
+    """
+    return 2.0 * (freq * time_array % 1.0) - 1.0
+
+
+def play_saw_wave(freq=None, duration=2.0, sample_rate=44100):
+    """Play a sawtooth wave using sounddevice.
+
+    Parameters
+    ----------
+    freq : float or None
+        If ``None``, a random frequency between 30 Hz and 45 Hz will be used.
+    duration : float
+        Length of the sound in seconds. Values outside the range 0.1–3 will
+        be clamped.
+    sample_rate : int
+        Audio sample rate in Hz.
+    """
+    if freq is None:
+        freq = random.uniform(30.0, 45.0)
+
+    duration = max(0.1, min(duration, 3.0))
+
+    t = np.linspace(0, duration, int(sample_rate * duration), endpoint=False)
+    wave = saw_wave(freq, t)
+    sd.play(wave, sample_rate)
+    sd.wait()
+
+
+if __name__ == "__main__":
+    play_saw_wave()


### PR DESCRIPTION
## Summary
- randomize sawtooth frequency between 30 and 45 Hz every run
- clamp playable duration between 0.1 and 3 seconds
- document the random behavior and duration range

## Testing
- `python -m py_compile saw_wave.py`
