### PR TITLE
Refine low-pass saw wave

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,27 @@
-fart machine
+# Fart Machine
+
+This repository contains a simple example of generating a sawtooth wave in Python.
+
+The `saw_wave.py` script plays a low-pitched sawtooth wave using `numpy`, `sounddevice`, and a basic low-pass filter from `scipy`.
+
+## Requirements
+
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Running the script generates a short, filtered saw wave each time using
+random values close to the defaults:
+
+- **Base frequency** – around 10 Hz (randomly between 8 Hz and 12 Hz)
+- **Low-pass cutoff** – around 1500 Hz (randomly between 1000 Hz and 2000 Hz)
+
+To hear it, run:
+
+```bash
+python saw_wave.py
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numpy
+sounddevice
+scipy

--- a/saw_wave.py
+++ b/saw_wave.py
@@ -1,0 +1,50 @@
+import numpy as np
+import sounddevice as sd
+from scipy.signal import butter, lfilter
+
+
+def saw_wave(freq, time_array):
+    """Generate a sawtooth wave.
+
+    Parameters
+    ----------
+    freq : float
+        Frequency of the wave in Hz.
+    time_array : numpy.ndarray
+        Array of time values.
+
+    Returns
+    -------
+    numpy.ndarray
+        The sawtooth waveform sampled at the times provided.
+    """
+    return 2.0 * (freq * time_array % 1.0) - 1.0
+
+
+def lowpass_filter(signal: np.ndarray, cutoff_hz: float, sample_rate: int,
+                   order: int = 2) -> np.ndarray:
+    """Apply a low-pass Butterworth filter to the signal."""
+    nyquist = sample_rate / 2.0
+    norm_cutoff = cutoff_hz / nyquist
+    b, a = butter(order, norm_cutoff, btype="low", analog=False)
+    return lfilter(b, a, signal)
+
+
+def play_saw_wave(sample_rate: int = 44100, duration: float = 2.0) -> None:
+    """Play a filtered sawtooth wave with slight randomization."""
+    base_freq = np.random.uniform(8.0, 12.0)
+    cutoff_hz = np.random.uniform(1000.0, 2000.0)
+
+    t = np.linspace(0, duration, int(sample_rate * duration), endpoint=False)
+    wave = saw_wave(base_freq, t)
+    filtered = lowpass_filter(wave, cutoff_hz, sample_rate)
+
+    print(
+        f"Playing {base_freq:.2f} Hz saw wave with {cutoff_hz:.0f} Hz low-pass filter"
+    )
+    sd.play(filtered, sample_rate)
+    sd.wait()
+
+
+if __name__ == "__main__":
+    play_saw_wave()


### PR DESCRIPTION
## Summary
- add basic low-pass filtering with SciPy
- randomize base frequency and cutoff slightly around default values
- document new behavior in the README
- list SciPy in requirements

## Testing
- `python -m py_compile saw_wave.py`
