### PR TITLE
Add randomized sawtooth with envelope and filtering

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,33 @@
-fart machine
+# Fart Machine
+
+This repository contains a small script that generates random sawtooth bursts using
+`numpy`, `scipy`, and `sounddevice`.
+
+Running the script plays a saw wave with a new random frequency, duration, and
+envelope every time.
+
+## Requirements
+
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run the script with:
+
+```bash
+python saw_wave.py
+```
+
+Each run will choose:
+
+- **Frequency:** 30–45 Hz
+- **Duration:** 0.1–3 seconds
+- **Attack:** 5–200 ms
+- **Release:** 50–700 ms
+
+The waveform is passed through a resonant low‑pass filter around 1500 Hz with a
+tiny amount of random variation to keep things fresh.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numpy
+sounddevice
+scipy

--- a/saw_wave.py
+++ b/saw_wave.py
@@ -1,0 +1,67 @@
+"""Generate and play random sawtooth bursts."""
+
+from __future__ import annotations
+
+import numpy as np
+import sounddevice as sd
+from scipy.signal import butter, lfilter
+
+
+def saw_wave(freq: float, time_array: np.ndarray) -> np.ndarray:
+    """Generate a sawtooth wave."""
+    return 2.0 * (freq * time_array % 1.0) - 1.0
+
+
+def amplitude_envelope(
+    length: int, sample_rate: int, attack: float, release: float
+) -> np.ndarray:
+    """Create an amplitude envelope with linear attack and release."""
+    env = np.ones(length)
+    a_len = int(sample_rate * attack)
+    r_len = int(sample_rate * release)
+
+    if a_len > 0:
+        env[:a_len] = np.linspace(0.0, 1.0, a_len)
+    if r_len > 0:
+        env[-r_len:] = np.linspace(1.0, 0.0, r_len)
+
+    return env
+
+
+def lowpass_filter(
+    signal: np.ndarray, cutoff_hz: float, sample_rate: int, order: int = 2
+) -> np.ndarray:
+    """Apply a basic resonant low-pass filter with slight cutoff variation."""
+    nyquist = sample_rate / 2.0
+    # introduce only a tiny random variation around the requested cutoff
+    jitter = np.random.uniform(-5.0, 5.0)
+    adjusted = np.clip(cutoff_hz + jitter, 20.0, nyquist - 1)
+    norm_cutoff = adjusted / nyquist
+    b, a = butter(order, norm_cutoff, btype="low", analog=False)
+    return lfilter(b, a, signal)
+
+
+def play_saw_wave(sample_rate: int = 44100) -> None:
+    """Generate a random sawtooth burst and play it."""
+    freq = np.random.uniform(30.0, 45.0)
+    duration = np.random.uniform(0.1, 3.0)
+    attack = np.random.uniform(0.005, 0.2)
+    release = np.random.uniform(0.05, 0.7)
+
+    t = np.linspace(0.0, duration, int(sample_rate * duration), endpoint=False)
+    wave = saw_wave(freq, t)
+    env = amplitude_envelope(len(wave), sample_rate, attack, release)
+    wave *= env
+    wave = lowpass_filter(wave, cutoff_hz=1500.0, sample_rate=sample_rate)
+
+    print(
+        f"Playing {freq:.1f} Hz for {duration:.2f} s "
+        f"(attack={attack:.3f}s, release={release:.3f}s)"
+    )
+    sd.play(wave, sample_rate)
+    sd.wait()
+
+
+if __name__ == "__main__":
+    play_saw_wave()
+


### PR DESCRIPTION
## Summary
- rewrite `saw_wave.py` to pick random frequency, duration, attack, and release values
- include a low-pass filter with slight variation each run
- update README with new behavior
- include SciPy in dependencies

## Testing
- `python -m py_compile saw_wave.py`
