### PR TITLE
Add resonant HPF stage

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ pip install -r requirements.txt
 
 ## Usage
 
-Running the script will pick a random frequency between 30 and 45 Hz and a random duration between 0.1 and 3 seconds. The waveform is shaped with a quick-attack, quick-release envelope and passed through a simple low-pass filter.
+Running the script will pick a random frequency between 8 and 12 Hz and a random duration between 0.1 and 3 seconds. The waveform is shaped with a quick-attack, quick-release envelope, filtered with a resonant low‑pass and high‑pass stage and finally run through a mild waveshaper.
 
 ```bash
 python saw_wave.py

--- a/saw_wave.py
+++ b/saw_wave.py
@@ -20,17 +20,39 @@ def amplitude_envelope(length: int, sample_rate: int, attack: float, release: fl
     return env
 
 
-def lowpass_filter(signal: np.ndarray, cutoff_hz: float, sample_rate: int, order: int = 2) -> np.ndarray:
-    """Apply a basic resonant low-pass filter."""
+def resonant_lowpass(
+    signal: np.ndarray, cutoff_hz: float, q: float, sample_rate: int
+) -> np.ndarray:
+    """Apply a two-pole state variable low-pass filter with resonance."""
+    f = 2.0 * np.sin(np.pi * cutoff_hz / sample_rate)
+    damping = 1.0 / max(q, 1e-6)
+    low = 0.0
+    band = 0.0
+    out = np.zeros_like(signal)
+    for i, x in enumerate(signal):
+        high = x - low - damping * band
+        band += f * high
+        low += f * band
+        out[i] = low
+    return out
+
+
+def highpass_filter(
+    signal: np.ndarray,
+    cutoff_hz: float,
+    sample_rate: int,
+    order: int = 2,
+) -> np.ndarray:
+    """Basic Butterworth high-pass filter."""
     nyquist = sample_rate / 2.0
     norm_cutoff = cutoff_hz / nyquist
-    b, a = butter(order, norm_cutoff, btype="low", analog=False)
+    b, a = butter(order, norm_cutoff, btype="high", analog=False)
     return lfilter(b, a, signal)
 
 
 def play_saw_wave(sample_rate: int = 44100) -> None:
     """Generate a random sawtooth burst and play it."""
-    freq = np.random.uniform(30.0, 45.0)
+    freq = np.random.uniform(8.0, 12.0)
     duration = np.random.uniform(0.1, 3.0)
     attack = np.random.uniform(0.005, 0.2)
     release = np.random.uniform(0.05, 0.2)
@@ -39,7 +61,10 @@ def play_saw_wave(sample_rate: int = 44100) -> None:
     wave = saw_wave(freq, t)
     env = amplitude_envelope(len(wave), sample_rate, attack, release)
     wave *= env
-    wave = lowpass_filter(wave, cutoff_hz=1500, sample_rate=sample_rate)
+    wave = resonant_lowpass(wave, cutoff_hz=1500, q=0.8, sample_rate=sample_rate)
+    wave = highpass_filter(wave, cutoff_hz=200.0, sample_rate=sample_rate)
+    drive = 2.0
+    wave = np.tanh(drive * wave)
 
     print(
         f"Playing {freq:.1f} Hz for {duration:.2f} s "


### PR DESCRIPTION
## Summary
- import scipy.signal to use Butterworth filters
- implement a simple high-pass filter
- apply the high-pass stage after the resonant low-pass
- document the new processing chain and frequency range

## Testing
- `python -m py_compile saw_wave.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement numpy)*