### PR TITLE
Add chorus and mod wheel processing

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ pip install -r requirements.txt
 
 ## Usage
 
-Running the script will pick a random frequency between 8 and 12 Hz and a random duration between 0.1 and 3 seconds. The waveform is shaped with a quick-attack, quick-release envelope, filtered with a resonant low‑pass and high‑pass stage and finally run through a mild waveshaper.
+Running the script will pick a random frequency between 8 and 12 Hz and a random duration between 0.1 and 3 seconds. The waveform is shaped with a quick-attack, quick-release envelope, filtered with a resonant low‑pass and high‑pass stage, run through a mild waveshaper and then thickened by a simple chorus effect. A random “mod wheel” value modulates the high-pass cutoff, drive and chorus mix each run.
 
 ```bash
 python saw_wave.py


### PR DESCRIPTION
## Summary
- add `saturator`, `chorus`, and `apply_modwheel` utilities
- process mod wheel value in `play_saw_wave`
- document chorus and mod wheel behavior

## Testing
- `python -m py_compile saw_wave.py`
