### PR TITLE
Adjust saw wave frequency range

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ pip install -r requirements.txt
 
 ## Usage
 
-Running the script will pick a random frequency between 8 and 12 Hz and a random duration between 0.1 and 3 seconds. The waveform is shaped with a quick-attack, quick-release envelope, filtered with a resonant low‑pass and high‑pass stage, run through a mild waveshaper and then thickened by a simple chorus effect. A random “mod wheel” value modulates the high-pass cutoff, drive and chorus mix each run.
+Running the script will pick a random frequency between 18 and 20 Hz and a random duration between 0.1 and 3 seconds. The waveform is shaped with a quick-attack, quick-release envelope, filtered with a resonant low‑pass and high‑pass stage, run through a mild waveshaper and then thickened by a simple chorus effect. A random “mod wheel” value modulates the high-pass cutoff, drive and chorus mix each run.
 
 ```bash
 python saw_wave.py


### PR DESCRIPTION
## Summary
- sweep the low-pass cutoff using a filter envelope
- raise the frequency range of the sawtooth from 8–12 Hz to 18–20 Hz
- document the new range in the readme

## Testing
- `python -m py_compile saw_wave.py`