### PR TITLE
Revert wavetable crossfade

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,7 @@
 # Fart Machine
 
-This repository demonstrates generating a short sawtooth burst in Python. Each execution produces a slightly different sound by randomizing several parameters.
+This repository demonstrates generating a short sawtooth burst in Python. Each
+execution produces a slightly different sound by randomizing several parameters.
 
 ## Requirements
 
@@ -12,7 +13,7 @@ pip install -r requirements.txt
 
 ## Usage
 
-Running the script will pick a random frequency between 18 and 20 Hz and a random duration between 0.1 and 3 seconds. The waveform is shaped with a quick-attack, quick-release envelope, filtered with a resonant low‑pass and high‑pass stage, run through a mild waveshaper and then thickened by a simple chorus effect. A random “mod wheel” value modulates the high-pass cutoff, drive and chorus mix each run.
+Running the script will pick a random frequency between 20 and 35 Hz and a random duration between 0.5 and 3 seconds. The waveform is shaped with a quick-attack, quick-release envelope, filtered with a resonant low-pass and high-pass stage, run through a mild waveshaper and then thickened by a simple chorus effect. A random “mod wheel” value modulates the high-pass cutoff, drive and chorus mix each run.
 
 ```bash
 python saw_wave.py

--- a/saw_wave.py
+++ b/saw_wave.py
@@ -130,8 +130,8 @@ def apply_modwheel(signal: np.ndarray, sample_rate: int, mod: float) -> np.ndarr
 
 def play_saw_wave(sample_rate: int = 44100) -> None:
     """Generate a random sawtooth burst and play it."""
-    freq = np.random.uniform(18.0, 20.0)
-    duration = np.random.uniform(0.1, 3.0)
+    freq = np.random.uniform(20.0, 35.0)
+    duration = np.random.uniform(0.5, 3.0)
     attack = np.random.uniform(0.005, 0.2)
     release = np.random.uniform(0.05, 0.2)
     mod = np.random.uniform(0.0, 1.0)


### PR DESCRIPTION
## Summary
- return to basic saw-wave burst
- update documentation for new frequency and duration ranges

## Testing
- `python -m py_compile saw_wave.py`
