### PR TITLE
Fix HPF resonance and audible frequency

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ pip install -r requirements.txt
 
 ## Usage
 
-Running the script will pick a random frequency between 20 and 35 Hz and a random duration between 0.5 and 3 seconds. The sawtooth is morphed toward a crude pulse wave via a second envelope, filtered with a resonant low-pass and high-pass stage, run through additional drive and finally limited. A simple chorus still thickens the sound, while a random “mod wheel” value modulates the high-pass cutoff and chorus depth each run.
+Running the script will pick a random frequency between 40 and 80 Hz and a random duration between 0.5 and 3 seconds. The sawtooth is morphed toward a crude pulse wave via a second envelope, filtered with a resonant low-pass and high-pass stage, run through additional drive and finally limited. A simple chorus still thickens the sound, while a random “mod wheel” value modulates the high-pass cutoff and chorus depth each run.
 
 ```bash
 python saw_wave.py

--- a/saw_wave.py
+++ b/saw_wave.py
@@ -149,7 +149,8 @@ def resonant_highpass(
             high = x_driven - low - damping * band
             band += f * high
             low += f * band
-            out[i] = np.tanh(high)
+            raw_hp = x_driven - low - damping * band
+            out[i] = raw_hp
     else:
         for i, x in enumerate(signal):
             f = 2.0 * np.sin(np.pi * cutoff_hz[i] / sample_rate)
@@ -157,7 +158,8 @@ def resonant_highpass(
             high = x_driven - low - damping * band
             band += f * high
             low += f * band
-            out[i] = np.tanh(high)
+            raw_hp = x_driven - low - damping * band
+            out[i] = raw_hp
     return out
 
 
@@ -289,7 +291,7 @@ def apply_modwheel(signal: np.ndarray, sample_rate: int, mod: float) -> np.ndarr
 
 def play_saw_wave(sample_rate: int = 44100) -> None:
     """Generate a random sawtooth burst and play it."""
-    raw_freq = np.random.uniform(20.0, 35.0)
+    raw_freq = np.random.uniform(40.0, 80.0)
     duration = np.random.uniform(0.5, 3.0)
     attack = np.random.uniform(0.005, 0.2)
     decay = np.random.uniform(0.05, 0.3)
@@ -367,7 +369,7 @@ def play_saw_wave(sample_rate: int = 44100) -> None:
     # ----- Remove rumble with slight resonance
     wave = resonant_highpass(
         signal=wave,
-        cutoff_hz=200.0,
+        cutoff_hz=30.0,
         q=1.2,
         sample_rate=sample_rate,
         drive=1.2,


### PR DESCRIPTION
## Summary
- update README: new frequency range noted
- tweak `resonant_highpass` to output raw high-pass signal
- generate slightly higher oscillation frequencies
- lower high-pass filter cutoff to 30 Hz so the note survives

## Testing
- `python saw_wave.py` *(fails: ModuleNotFoundError: No module named 'numpy')*